### PR TITLE
Proper comparison of JSON body using JToken #7

### DIFF
--- a/Blueprint.Aspnet.Module/Blueprint.Aspnet.Module.csproj
+++ b/Blueprint.Aspnet.Module/Blueprint.Aspnet.Module.csproj
@@ -45,9 +45,6 @@
     <OutputPath>bin\x86\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DeepEqual">
-      <HintPath>..\packages\DeepEqual.1.1.1.0\lib\net40\DeepEqual.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Blueprint.Aspnet.Module/BlueprintModule.cs
+++ b/Blueprint.Aspnet.Module/BlueprintModule.cs
@@ -6,8 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Web;
 using Blueprint.Aspnet.Module.Extensions;
-using DeepEqual.Syntax;
-using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using snowcrashCLR;
 
 namespace Blueprint.Aspnet.Module
@@ -166,10 +165,18 @@ namespace Blueprint.Aspnet.Module
 
         private bool MatchJson(string requestBody, string payloadBody)
         {
-            var requestObject = JsonConvert.DeserializeObject(requestBody);
-            var payloadObject = JsonConvert.DeserializeObject(payloadBody);
+            var requestJson = string.IsNullOrWhiteSpace(requestBody)
+                ? "{}"
+                : requestBody;
 
-            return requestObject.IsDeepEqual(payloadObject);
+            var blueprintJson = string.IsNullOrWhiteSpace(payloadBody)
+                ? "{}"
+                : payloadBody;
+
+            var requestObject = JToken.Parse(requestJson);
+            var blueprintObject = JToken.Parse(blueprintJson);
+
+            return JToken.DeepEquals(requestObject, blueprintObject);
         }
 
         private void Application_EndRequest(Object source, EventArgs e)

--- a/Blueprint.Aspnet.Module/packages.config
+++ b/Blueprint.Aspnet.Module/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DeepEqual" version="1.1.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Snowcrash.NET" version="1.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
this should fix the JSON comparison problem when the order of properties is different in JSON body. also eleminates the need/dependency for DeepEqual nuget package
